### PR TITLE
Removed WebSocket::read() timeout

### DIFF
--- a/src/WebSocket.cpp
+++ b/src/WebSocket.cpp
@@ -228,16 +228,6 @@ WebSocket::WebSocket(const NetClient &client)
   : m_client(client), m_readyState(ReadyState::OPEN), m_maskEnabled(false) {}
 
 int32_t WebSocket::_read() {
-  const uint32_t timeout{ millis() + kTimeoutInterval };
-  while (!m_client.available() && millis() < timeout) {
-    delay(1);
-  }
-
-  if (millis() > timeout) {
-    close(PROTOCOL_ERROR, true);
-    return -1;
-  }
-
   return m_client.read();
 }
 


### PR DESCRIPTION
This is a modification I use in my projects (private repositories). In my experience it works without problems, however it didn't make it into [the official library](https://github.com/skaarj1989/mWebSockets) because as discussed on [#31](https://github.com/skaarj1989/mWebSockets/pull/31) it doesn't pass some autobahn tests.

However I have never had problems lol.